### PR TITLE
Fix infinite loop when initializing trimmed LUKS header.

### DIFF
--- a/libluksmeta.c
+++ b/libluksmeta.c
@@ -119,6 +119,8 @@ readall(int fd, void *data, size_t size)
         r = read(fd, &tmp[t], size - t);
         if (r < 0 && errno != EAGAIN)
             return -errno;
+        if (r == 0)
+            return -ENOENT;
     }
 
     return size;


### PR DESCRIPTION
The luksHeaderBackup stores only real used LUKS metadata, so
reading of such a header can return EOF.