### PR TITLE
Force creation of LUKS1 containers in test suite

### DIFF
--- a/test-luksmeta
+++ b/test-luksmeta
@@ -11,7 +11,7 @@ function onexit() {
 trap 'onexit' EXIT
 
 truncate -s 4M $tmp
-echo -n foo | cryptsetup luksFormat $tmp -
+echo -n foo | cryptsetup luksFormat --type luks1 $tmp -
 
 ! ./luksmeta test -d $tmp
 


### PR DESCRIPTION
Cryptsetup defaults to LUKS2 since version 2.1, make sure to create LUKS1 containers instead by using the "--type luks1" argument. This applies the [patch](https://sources.debian.org/patches/luksmeta/9-3/fix.test-luksmeta.patch/) by @cbiedl, closes #9.